### PR TITLE
Dockerize Application and Add Installation Instructions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,18 +7,17 @@ RUN apt-get -y install software-properties-common git curl apt-transport-https c
 # Install pcre2
 RUN apt-get install -y libpcre2-dev libpcre2-8-0 pcre2-utils
 
+# Install nodejs && yarn
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get update && apt-get -y install nodejs yarn
+
 # Install mimic
 RUN add-apt-repository -y ppa:mycroft-ai/mycroft-ai
 RUN apt-get update
-RUN apt-get install -y mimic 
-# Install nodejs
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
-RUN apt-get install -y nodejs
-
-# Install Yarn
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update && apt-get -y install yarn
+RUN apt-get install -y mimic
+RUN rm /usr/lib/*/libttsmimic*.a
 
 # Create necessary directories in root
 RUN mkdir /root/.cache /root/.config

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,34 @@
 FROM ubuntu:16.04
 
-RUN mkdir /almond
-COPY . /almond
-
 # Install sudo, git, curl, libpulse, and https sources support
-RUN apt-get update && apt-get -y install sudo
-RUN sudo apt-get -y install software-properties-common git curl apt-transport-https ca-certificates libpulse-dev
+RUN apt-get update
+RUN apt-get -y install software-properties-common git curl apt-transport-https ca-certificates libpulse-dev
 
 # Install pcre2
-RUN sudo apt-get install -y libpcre2-dev libpcre2-8-0 pcre2-utils
+RUN apt-get install -y libpcre2-dev libpcre2-8-0 pcre2-utils
 
 # Install mimic
-RUN sudo add-apt-repository -y ppa:mycroft-ai/mycroft-ai
-RUN sudo apt-get update
-RUN sudo apt-get install -y mimic
-
+RUN add-apt-repository -y ppa:mycroft-ai/mycroft-ai
+RUN apt-get update
+RUN apt-get install -y mimic 
 # Install nodejs
-RUN curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
-RUN sudo apt-get install -y nodejs
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN apt-get install -y nodejs
 
 # Install Yarn
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-RUN sudo apt-get update && sudo apt-get -y install yarn
-
-RUN yarn
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get update && apt-get -y install yarn
 
 # Create necessary directories in root
 RUN mkdir /root/.cache /root/.config
 
+RUN mkdir /opt/almond
+COPY . /opt/almond
+RUN rm -rf /opt/almond/node_modules
+WORKDIR /opt/almond
+RUN yarn
+
 EXPOSE 3000
+
+ENTRYPOINT [ "yarn", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:16.04
+
+RUN mkdir /almond
+COPY . /almond
+
+# Install sudo, git, curl, libpulse, and https sources support
+RUN apt-get update && apt-get -y install sudo
+RUN sudo apt-get -y install software-properties-common git curl apt-transport-https ca-certificates libpulse-dev
+
+# Install pcre2
+RUN sudo apt-get install -y libpcre2-dev libpcre2-8-0 pcre2-utils
+
+# Install mimic
+RUN sudo add-apt-repository -y ppa:mycroft-ai/mycroft-ai
+RUN sudo apt-get update
+RUN sudo apt-get install -y mimic
+
+# Install nodejs
+RUN curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+RUN sudo apt-get install -y nodejs
+
+# Install Yarn
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+RUN sudo apt-get update && sudo apt-get -y install yarn
+
+RUN yarn
+
+# Create necessary directories in root
+RUN mkdir /root/.cache /root/.config
+
+EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -12,3 +12,19 @@ Almond is part of Open Thing Platform, a research project led by
 prof. Monica Lam, from Stanford University.  You can find more
 information at <https://thingpedia.stanford.edu/about>.
 
+## To Run
+
+This assumes that you have [docker](https://docs.docker.com/install/) and [docker-compose](https://docs.docker.com/compose/install/) installed, with at least **2 GB** of available diskspace. Please be sure to be on a **fast internet connection** before running through this process for the first time.
+
+1. Clone this repo to your machine.
+```
+git clone https://github.com/stanford-oval/almond-server.git
+```
+
+2. Run docker-compose.  
+```
+docker-compose up
+```
+**Note:** This command can take a long time depending on the speed of your internet connection as well as your access to processing power.
+
+3. Navigate to [localhost:3000](http://localhost:3000) to access Almond.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,6 @@ version: "3.7"
 services:
   web:
     build: .
-    command: bash -c "cd /almond && yarn start"
+    command: bash -c "cd /opt/almond && yarn start"
     ports:
       - "3000:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3.7"
+services:
+  web:
+    build: .
+    command: bash -c "cd /almond && yarn start"
+    ports:
+      - "3000:3000"

--- a/docker_scripts/install_mimic.sh
+++ b/docker_scripts/install_mimic.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-cd /
-git clone https://github.com/MycroftAI/mimic1.git
-cd mimic1
-./dependencies.sh --prefix="/usr/local"
-./autogen.sh
-./configure --prefix="/usr/local"
-make
-make check

--- a/docker_scripts/install_mimic.sh
+++ b/docker_scripts/install_mimic.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+cd /
+git clone https://github.com/MycroftAI/mimic1.git
+cd mimic1
+./dependencies.sh --prefix="/usr/local"
+./autogen.sh
+./configure --prefix="/usr/local"
+make
+make check

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint": "^6.0.0",
     "nyc": "^14.1.1",
     "parse5": "^5.1.0",
-    "selenium-webdriver": "^4.0.0-alpha.4"
+    "selenium-webdriver": "^4.0.0-alpha.5"
   },
   "nyc": {
     "exclude": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3566,10 +3566,10 @@ sax@>=0.6.0, sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-selenium-webdriver@^4.0.0-alpha.4:
-  version "4.0.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/selenium-webdriver/-/selenium-webdriver-4.0.0-alpha.4.tgz#73694490e02c941d9d0bf7a36f7c49beb9372512"
-  integrity sha512-etJt20d8qInkxMAHIm5SEpPBSS+CdxVcybnxzSIB/GlWErb8pIWrArz/VA6VfUW0/6tIcokepXQ5ufvdzqqk1A==
+selenium-webdriver@^4.0.0-alpha.5:
+  version "4.0.0-alpha.5"
+  resolved "https://registry.yarnpkg.com/selenium-webdriver/-/selenium-webdriver-4.0.0-alpha.5.tgz#e4683b3dbf827d70df09a7e43bf02ebad20fa7c1"
+  integrity sha512-hktl3DSrhzM59yLhWzDGHIX9o56DvA+cVK7Dw6FcJR6qQ4CGzkaHeXQPcdrslkWMTeq0Ci9AmCxq0EMOvm2Rkg==
   dependencies:
     jszip "^3.1.5"
     rimraf "^2.6.3"


### PR DESCRIPTION
Make it much easier to get almond-server up and running with the help of docker and docker-compose, installing all the necessary packages and mimic in a standardized environment.