### PR TITLE
Add a portable version of the docker build

### DIFF
--- a/Dockerfile.portable
+++ b/Dockerfile.portable
@@ -1,0 +1,19 @@
+FROM docker.io/fedora:30
+
+# Install all deps in the standard repos
+RUN dnf -y install git unzip nodejs make gcc gcc-c++
+
+# Install yarn
+RUN curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo
+RUN dnf -y install yarn
+
+RUN mkdir /opt/almond
+COPY . /opt/almond
+RUN rm -rf /opt/almond/node_modules
+WORKDIR /opt/almond
+RUN yarn && rm -fr /root/.cache
+
+EXPOSE 3000
+ENV THINGENGINE_HOME=/var/lib/almond-server
+
+ENTRYPOINT [ "yarn", "start"]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ podman run -p 3000:3000 --uidmap keep-id \
 
 You can now navigate to [127.0.0.1:3000](http://127.0.0.1:3000) to access Almond, or use your voice with the hotword "Almond".
 
+### I am a Mac!
+
+Voice support is only available on Linux. On Mac or Windows, you can use the following docker command:
+
+```bash
+docker run -p 3000:3000 \
+    -v $HOME/.almond-server:/var/lib/almond-server \
+    stanfordoval/almond-server:latest-portable
+```
+
+Change the `-v` line to a different path to save the almond-server configuration files in a different directory than `$HOME/.almond-server`.
+
 ## Development setup
 
 To develop almond-server, you should clone this repository, then install the dependencies with:


### PR DESCRIPTION
That can run on Windows/Mac (using a light-weight VM), without PulseAudio
or any of the voice deps