### PR TITLE
Set the title correctly when the user clicks a choice message

### DIFF
--- a/public/javascripts/conversation.js
+++ b/public/javascripts/conversation.js
@@ -209,7 +209,7 @@ $(() => {
         var btn = $('<a>').addClass('message message-choice btn btn-default')
             .attr('href', '#').text(title);
         btn.click((event) => {
-            handleChoice(idx);
+            handleChoice(idx, title);
             event.preventDefault();
         });
         holder.append(btn);


### PR DESCRIPTION
Otherwise, the user's command in the history will be display using
raw JSON, which is ugly.

Fixes #143