### PR TITLE
Fix redirect to almond cloud oauth proxy when the Almond is embedded ...

### DIFF
--- a/public/javascripts/devices-create.js
+++ b/public/javascripts/devices-create.js
@@ -4,6 +4,22 @@ $(() => {
         return document.body.dataset.thingpediaUrl;
     }
 
+    function isIframe() {
+        try {
+            return window.self !== window.top;
+        } catch (e) {
+            return true;
+        }
+    }
+
+    function isCrossOrigin() {
+        try {
+            return window.frameElement !== null;
+        } catch (e) {
+            return true;
+        }
+    }
+
     function handleOnlineAccountFactory(json, kind, name) {
         console.log('Handling online account ' + kind);
         const self = $('<div>');
@@ -64,6 +80,8 @@ $(() => {
                 btn.attr('href', json.href);
                 break;
             case 'oauth2':
+                if (isIframe())
+                    btn.attr('target', isCrossOrigin() ? '_blank' : '_parent');
                 btn.attr('href', 'oauth2/' + kind);
                 break;
             default: // discovery or builtin, ignore

--- a/public/javascripts/devices-create.js
+++ b/public/javascripts/devices-create.js
@@ -13,11 +13,7 @@ $(() => {
     }
 
     function isCrossOrigin() {
-        try {
-            return window.frameElement !== null;
-        } catch (e) {
-            return true;
-        }
+        return window.frameElement !== null;
     }
 
     function handleOnlineAccountFactory(json, kind, name) {

--- a/service/frontend.js
+++ b/service/frontend.js
@@ -102,8 +102,17 @@ module.exports = class WebFrontend extends events.EventEmitter {
 
         this._app.use((req, res, next) => {
             let port = ':' + this._app.get('port');
-            if (Config.HAS_REVERSE_PROXY ||
-                (req.protocol === 'http' && port === ':80') ||
+            if (Config.HAS_REVERSE_PROXY) {
+                if (req.headers['x-forwarded-port']) {
+                    port = (':' + req.headers['x-forwarded-port']);
+                } else if (req.headers['x-forwarded-host']) {
+                    let tmp = req.headers['x-forwarded-host'].split(':');
+                    port = tmp[1] ? (':' + tmp[1]) : '';
+                } else {
+                    port = '';
+                }
+            }
+            if ((req.protocol === 'http' && port === ':80') ||
                 (req.protocol === 'https' && port === ':443'))
                 port = '';
             this._platform._setOrigin(req.protocol + '://' + req.hostname + port);


### PR DESCRIPTION
It's possible to distinguish 2 different iframe embedding scenarios:
1) on same origin: we can (still) redirect the parent window
2) on cross origin (for example in case of Home Assistant): open in a new tab

The patch implements both.