### PR TITLE
adding an emit for when smartnews audio process is killed

### DIFF
--- a/service/platform/index.js
+++ b/service/platform/index.js
@@ -183,8 +183,10 @@ class Player extends events.EventEmitter {
     }
 
     async stop() {
-        if (this._child)
+        if (this._child) {
+            this.emit('stopChain'); // emitted when stop is called, lets agent know to stop playing current audio and all subsequent audios
             this._child.kill();
+          }
     }
 }
 


### PR DESCRIPTION
emits when the user no longer wants to listen to news, and lets the agent know to stop queuing news articles to be read. Solves issue#318 in thingpedia-common-devices: https://github.com/stanford-oval/thingpedia-common-devices/issues/318