### PR TITLE
Chat border + scrollbar fixes plus config checkbox alignment

### DIFF
--- a/public/stylesheets/conversation.css
+++ b/public/stylesheets/conversation.css
@@ -12,10 +12,9 @@
 }
 
 #conversation #chat {
-    margin: 1em 0em;
     overflow-y: scroll;
     height: -webkit-fill-available;
-    padding: 5px 35px;
+    padding: 20px 35px;
     height: 595px;
     overflow-anchor: none;
 }
@@ -93,6 +92,8 @@
     max-height: 100%;
     border-bottom-left-radius: 20px;
     border-bottom-right-radius: 20px;
+    border: 1px solid #585858;
+    border-top: 0;
 }
 
 #conversation .message-rdl-title {
@@ -197,6 +198,8 @@
     border-top-right-radius: 15px;
     text-align: right;
     padding-right: 15px;
+    border: 1px solid #585858;
+    border-bottom: 0;
 }
 
 .comment-options {

--- a/public/stylesheets/my_stuff.css
+++ b/public/stylesheets/my_stuff.css
@@ -19,7 +19,6 @@
     justify-content: space-between;
 }
 
-
 .bottom-bar.fa,
 .bottom-bar.far {
     cursor: pointer;

--- a/views/config.pug
+++ b/views/config.pug
@@ -62,7 +62,7 @@ block content
     div.panel-body.panel-body-conf
       form(action=Config.BASE_URL + '/config/set-options',method='post',data-toggle='validator')
         input(type='hidden',name='_csrf',value=csrfToken)
-        div.form-group
+        div.form-group.form-inline
           div.checkbox
             label(for='setting-data-collection').control-label
               input(type='checkbox',name='data_collection',value='1',checked=settings.data_collection)#setting-data-collection
@@ -70,13 +70,13 @@ block content
             span.help-block
               != _("Almond is a research project from Stanford University. If you would like to participate to help us, you can allow us to collect the commands that you type. We only collect what you type, not your data, or what Almond replies. Please review the <a href='https://oval.cs.stanford.edu/almond-consent-form.html'>Consent Form</a> and keep it for your records before agreeing.")
 
-        div.form-group
+        div.form-group.form-inline
           div.checkbox
             label(for='setting-voice-input').control-label
               input(type='checkbox',name='voice_input',value='1',checked=settings.voice_input)#setting-voice-input
               = _(" Enable voice input (wake word activation and speech to text).")
 
-        div.form-group
+        div.form-group.form-inline
           div.checkbox
             label(for='setting-voice-output').control-label
               input(type='checkbox',name='voice_output',value='1',checked=settings.voice_output)#setting-voice-output


### PR DESCRIPTION
**Chat:**
1. Add border around main element (to be consistent with skill and rules)
2. Convert margin to padding so that scrollbar properly uses the complete height of the chat log area

**Config:**
1. Properly align checkboxes with their label

I also noticed that for skills and rules the footer color is a different (lighter) shade of dark red compared to the navigation header. When I applied that same lighter color to the chat input area however, it looked weird in overall visual context, so I left it as it is.

**Before:**
![image](https://user-images.githubusercontent.com/114137/119206786-74130480-ba9c-11eb-8ee6-a72fa17ff635.png)

![image](https://user-images.githubusercontent.com/114137/119206770-6a899c80-ba9c-11eb-8688-e41c48671e6f.png)


**After:**
![image](https://user-images.githubusercontent.com/114137/119206721-45952980-ba9c-11eb-939a-957a25d402df.png)

![image](https://user-images.githubusercontent.com/114137/119206747-59409000-ba9c-11eb-9e14-b6cd56e0ab91.png)
