### PR TITLE
Improve README for running almond-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ information at <https://thingpedia.stanford.edu/about>.
 ## Running almond-server
 
 The recommended way to run almond-server is through [podman](https://podman.io/), a replacement for [docker](https://docs.docker.com/install/) that allows
-the container to run as your regular user (and thus access PulseAudio from your normal session).
+the container to run as your regular user (and thus access PulseAudio from your normal session). You can find the installation instructions [here](https://podman.io/getting-started/installation).
 
 To run, use the command:
 ```bash
@@ -27,6 +27,13 @@ podman run --name almond -p 3000:3000 \
 ```
 
 You can now navigate to [127.0.0.1:3000](http://127.0.0.1:3000) to access Almond, or use your voice with the hotword "computer".
+
+To manage the container later, you can use:
+```bash
+podman start almond # start the container again
+podman stop almond # stop the container
+podman logs almond # look at the most recent logs of a running container
+```
 
 ### I am a Mac!
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ podman run --name almond -p 3000:3000 \
     -v /dev/shm:/dev/shm \
     -v $XDG_RUNTIME_DIR/pulse:/run/pulse \
     --security-opt label=disable \
-    stanfordoval/almond-server
+    docker.io/stanfordoval/almond-server
 ```
 
 You can now navigate to [127.0.0.1:3000](http://127.0.0.1:3000) to access Almond, or use your voice with the hotword "computer".


### PR DESCRIPTION
This does _not_ solve the issue described in #212 where podman fails to pull the image when unqualified-search-registries is empty; I've got some sort of auth issue that prevents this command (which I think is preferable) from working:

```
$ podman run --name almond -p 3000:3000 \
    -v /dev/shm:/dev/shm \
    -v $XDG_RUNTIME_DIR/pulse:/run/pulse \
    --security-opt label=disable \
    docker.io/almond-server:latest

Trying to pull docker.io/library/almond-server:latest...
  denied: requested access to the resource is denied
Error: Error initializing source docker://almond-server:latest: Error reading manifest latest in docker.io/library/almond-server: errors:
denied: requested access to the resource is denied
unauthorized: authentication required
```

Closes #212 otherwise.