### PR TITLE
Fix OAuth in Home Assistant add-on

### DIFF
--- a/config.js
+++ b/config.js
@@ -74,6 +74,12 @@ module.exports.HOST_BASED_AUTHENTICATION = process.env.THINGENGINE_HOST_BASED_AU
 */
 module.exports.ENABLE_DB_ENCRYPTION = false;
 
+/**
+  Adjust operation to run inside an Home Assistant add-on.
+
+  This affects the behavior of the OAuth proxy.
+*/
+module.exports.IN_HOME_ASSISTANT_ADDON = !!process.env.THINGENGINE_IN_HOME_ASSISTANT_ADDON;
 
 module.exports.NLP_URL = process.env.THINGENGINE_NLP_URL || 'https://nlp.almond.stanford.edu';
 module.exports.THINGPEDIA_URL = process.env.THINGPEDIA_URL || 'https://thingpedia.stanford.edu/thingpedia';

--- a/public/javascripts/.eslintrc.yml
+++ b/public/javascripts/.eslintrc.yml
@@ -4,6 +4,7 @@ env:
 globals:
   $: false
 extends: 'eslint:recommended'
+root: true
 rules:
   indent: off
   linebreak-style:

--- a/public/javascripts/shared.js
+++ b/public/javascripts/shared.js
@@ -1,7 +1,30 @@
+"use strict";
 (function() {
     window.Almond = {
         getThingpedia: function() {
             return 'https://thingpedia.stanford.edu';
         }
     };
+
+    const top = window.parent.location;
+    if (!top)
+        return;
+    const params = new URLSearchParams(top.search.substring(1));
+    if (params.has('almond_redirect')) {
+        const parsed = new URL(params.get('almond_redirect'), window.location.href);
+
+        // for security reasons, we ignore the protocol/hostname/port
+        // and only allow safe-listed paths
+        if (!parsed.pathname.startsWith('/devices/oauth2/callback/'))
+            return;
+
+        let redirectTo = parsed.pathname;
+        for (const [key, value] of params) {
+            if (key === 'almond_redirect')
+                continue;
+            parsed.searchParams.append(key, value);
+        }
+        redirectTo += '?' + parsed.searchParams;
+        window.location.href = redirectTo;
+    }
 })();

--- a/public/javascripts/shared.js
+++ b/public/javascripts/shared.js
@@ -1,21 +1,20 @@
 "use strict";
-(function() {
+$(function() {
     window.Almond = {
         getThingpedia: function() {
             return 'https://thingpedia.stanford.edu';
         }
     };
 
-    const top = window.parent.location;
-    if (!top)
-        return;
-    const params = new URLSearchParams(top.search.substring(1));
+    const top = window.parent;
+    const url = new URL(top.location.href);
+    const params = url.searchParams;
     if (params.has('almond_redirect')) {
         const parsed = new URL(params.get('almond_redirect'), window.location.href);
 
         // for security reasons, we ignore the protocol/hostname/port
         // and only allow safe-listed paths
-        if (!parsed.pathname.startsWith('/devices/oauth2/callback/'))
+        if (!parsed.pathname.startsWith(document.body.dataset.baseUrl + '/devices/oauth2/callback/'))
             return;
 
         let redirectTo = parsed.pathname;
@@ -25,6 +24,11 @@
             parsed.searchParams.append(key, value);
         }
         redirectTo += '?' + parsed.searchParams;
+
+        // remove the query params from the top URL
+        url.search = '';
+        top.history.replaceState(null, '', url.toString());
+
         window.location.href = redirectTo;
     }
-})();
+});


### PR DESCRIPTION
To workaround the strict cookie security setting, we need to redirect to the Home Assistant dashboard page (which doesn't need a cookie) with a special query string, read the query string, and then redirect to the right page inside the frame.