### PR TITLE
build arm64 docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,4 @@ jobs:
       - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
       - docker buildx create --use
       script:
-      - docker buildx build --platform linux/amd64 -t stanfordoval/almond-server:latest --push .
+      - docker buildx build --platform linux/amd64,linux/arm64 -t stanfordoval/almond-server:latest --push .


### PR DESCRIPTION
This adds `arm64` build target for the docker build. This should allow it to run on Raspberry Pis and other arm based platforms

Fixes https://github.com/stanford-oval/genie-server/issues/228
Relates to https://github.com/stanford-oval/genie-server/pull/298